### PR TITLE
Set parallel parsing on command line

### DIFF
--- a/TestSuite.settings.json
+++ b/TestSuite.settings.json
@@ -1,1 +1,1 @@
-{ "num-triples-per-batch": 1000000, "parallel-parsing" : false}
+{ "num-triples-per-batch": 1000000 }

--- a/backend/config_manager.py
+++ b/backend/config_manager.py
@@ -33,7 +33,7 @@ def create_config(
         "HOST": host,
         "GRAPHSTORE": graphstore,
         "NEWPATH": newpath,
-        "command_index": f"{path_to_index_builder} -s TestSuite.settings.json -i TestSuite ",
+        "command_index": f"{path_to_index_builder} -s TestSuite.settings.json -i TestSuite -p false",
         "command_start_server": f"{path_to_server_main} -i TestSuite -j 8 -p {port} > TestSuite.server-log.txt",
         "command_stop_server": f"pkill -f '{path_to_server_main} -i [^ ]*TestSuite'",
         "command_remove_index": "rm -f TestSuite.index.* TestSuite.vocabulary.* TestSuite.prefixes TestSuite.meta-data.json TestSuite.index-log.txt",


### PR DESCRIPTION
It is deprecated for a while now to specify `parallel-parsing` in the `.settings.json`. And for multiple input streams, it's forbidden. Set it on the command line instead via `-p false`.