### PR TITLE
Fix the concat expression in Update.rq

### DIFF
--- a/queries/Update.rq
+++ b/queries/Update.rq
@@ -8,7 +8,7 @@ PREFIX sd:      <http://www.w3.org/ns/sparql-service-description#>
 PREFIX ent:     <http://www.w3.org/ns/entailment/RDF>
 PREFIX rs:      <http://www.w3.org/2001/sw/DataAccess/tests/result-set#>
 
-SELECT DISTINCT ?type ?name ?query ?result ?data ?test ?feature ?comment ?approval ?approvedBy ?regime (GROUP_CONCAT(DISTINCT CONCAT(STR(?actionGraphStore), "%", STR(?actionGraphLabel)); SEPARATOR=";") AS ?graphDatas) (GROUP_CONCAT(DISTINCT CONCAT(STR(?resultGraphStore), "%", STR(?resultGraphLabel)); SEPARATOR=";") AS ?resultgraphDatas) 
+SELECT DISTINCT ?type ?name ?query ?result ?data ?test ?feature ?comment ?approval ?approvedBy ?regime (GROUP_CONCAT(DISTINCT COALESCE(CONCAT(STR(?actionGraphStore), "%", STR(?actionGraphLabel)), "%"); SEPARATOR=";") AS ?graphDatas) (GROUP_CONCAT(DISTINCT COALESCE(CONCAT(STR(?resultGraphStore), "%", STR(?resultGraphLabel)), "%"); SEPARATOR=";") AS ?resultgraphDatas)
 WHERE {
     ?test rdf:type mf:UpdateEvaluationTest .
     BIND ("UpdateEvaluationTest" AS ?type) .


### PR DESCRIPTION
The `Update.rq`query so far relied on a relaxed and non-conforming beahvior in the `CONCAT` function, namely that unbound arguments are ignored. This PR adds additional `COALESCE` functions to make sure that this query also works with a standard-conforming SPARQL engine.