### PR TITLE
Fix: Now sets the correct content type for UpdateSyntaxTest queries

### DIFF
--- a/testsuite.py
+++ b/testsuite.py
@@ -397,9 +397,13 @@ class TestSuite:
                 continue
 
             for test in graphs_list_of_tests[graph_path]:
+                content_type = "rq"
+                if "Update" in test.typeName:
+                    content_type = "ru"
+
                 query_result = qlever.query(
                     test.queryFile,
-                    "rq",
+                    content_type,
                     "srx",
                     self.config.server_address,
                     self.config.port)


### PR DESCRIPTION
The content type for all syntax queries was `application/sparql-query;` causing all `UpdateSyntaxTests` to fail.
Now they get the correct content type `application/sparql-update;`