### PR TITLE
Fix: extract all listed content types in the expected protocol response

### DIFF
--- a/backend/protocol_tools.py
+++ b/backend/protocol_tools.py
@@ -48,8 +48,11 @@ def prepare_response(request_with_reponse: str) -> str:
             line = line.replace("Content-Type:", "")
             content_types = line.strip().split("or")
             for content_type in content_types:
-                response["content_types"].append(
-                    content_type.strip().split(";")[0])
+                # Split on ',' to handle multiple content types
+                cts = content_type.split(",")
+                for ct in cts:
+                    if ct != "":
+                        response["content_types"].append(ct.strip().split(";")[0])
         if line.startswith("true"):
             response["result"] = "true"
         if line.startswith("false"):


### PR DESCRIPTION
First fix for Issue #17 .
A protocol test failed because several content types were given using a comma. 
Now we can handle given content types split by ',' and 'or'.

Before:
{'status_codes': ['2xx', '3xx'], 'content_types': ['application/sparql-results+xml, application/sparql-results+json, text/tab-separated-values,', 'text/csv']}
After fix:
{'status_codes': ['2xx', '3xx'], 'content_types': ['application/sparql-results+xml', 'application/sparql-results+json', 'text/tab-separated-values', 'text/csv']}
This fixed one test: query appropriate content type (expect one of: XML, JSON, CSV, TSV)