### PR TITLE
Fix query for standard-compliant `GROUP_CONCAT`

### DIFF
--- a/queries/Query.rq
+++ b/queries/Query.rq
@@ -8,7 +8,7 @@ PREFIX sd:      <http://www.w3.org/ns/sparql-service-description#>
 PREFIX ent:     <http://www.w3.org/ns/entailment/RDF>
 PREFIX rs:      <http://www.w3.org/2001/sw/DataAccess/tests/result-set#>
 
-SELECT DISTINCT ?type ?name ?query ?result ?data ?test (GROUP_CONCAT(DISTINCT ?feature; SEPARATOR=";") AS ?featureList) ?comment ?approval (GROUP_CONCAT(DISTINCT ?approvedBy; SEPARATOR=";") AS ?approvedByList) ?regime (GROUP_CONCAT(DISTINCT ?actionGraphData; SEPARATOR=";") AS ?graphDatas) ?resultgraphData
+SELECT DISTINCT ?type ?name ?query ?result ?data ?test (GROUP_CONCAT(DISTINCT COALESCE(STR(?feature), ""); SEPARATOR=";") AS ?featureList) ?comment ?approval (GROUP_CONCAT(DISTINCT COALESCE(STR(?approvedBy), ""); SEPARATOR=";") AS ?approvedByList) ?regime (GROUP_CONCAT(DISTINCT COALESCE(STR(?actionGraphData), ""); SEPARATOR=";") AS ?graphDatas) ?resultgraphData
 WHERE {
     ?test rdf:type mf:QueryEvaluationTest .
     BIND ("QueryEvaluationTest" AS ?type) .


### PR DESCRIPTION
This should fix the query to work with a standard compliant `GROUP_CONCAT`, that doesn't process IRIs and propagates undefined as changed in https://github.com/ad-freiburg/qlever/pull/2092