### PR TITLE
Fix: language tags are now case-insensitive

### DIFF
--- a/backend/xml_tools.py
+++ b/backend/xml_tools.py
@@ -218,7 +218,13 @@ def xml_elements_equal(
         if isinstance(element1.attrib, dict):
             if element1.attrib.get("datatype") is None and element2.attrib.get(
                     "datatype") is None:
-                return False
+                # Check if language tags are equal, treat them as case-insensitive ex. en-US = en-us
+                xml_lang_key = '{http://www.w3.org/XML/1998/namespace}lang'
+                if xml_lang_key in element1.attrib and xml_lang_key in element2.attrib:
+                    if not element1.attrib[xml_lang_key].lower() == element2.attrib[xml_lang_key].lower():
+                        return False
+                else:
+                    return False
             else:
                 if (alias.get(element1.attrib.get("datatype")) != element2.attrib.get("datatype") and alias.get(
                         element2.attrib.get("datatype")) != element1.attrib.get("datatype")) or not compare_with_intended_behaviour:


### PR DESCRIPTION
Language tags are now treated as case-insensitive. 'en-US' now is considered equal to 'en-us'
#20
