### PR TITLE
Change accepted content type to ttl format for certain syntax tests.

### DIFF
--- a/testsuite.py
+++ b/testsuite.py
@@ -398,13 +398,15 @@ class TestSuite:
 
             for test in graphs_list_of_tests[graph_path]:
                 content_type = "rq"
+                result_format = "srx"
                 if "Update" in test.typeName:
                     content_type = "ru"
-
+                if "construct" in test.name:
+                    result_format = "ttl"
                 query_result = qlever.query(
                     test.queryFile,
                     content_type,
-                    "srx",
+                    result_format,
                     self.config.server_address,
                     self.config.port)
                 if query_result[0] != 200:


### PR DESCRIPTION
For syntax tests which have 'construct' in their name, use the ttl as the accepted content type.

Fix #24 .