### PR TITLE
Add: Tests now can be excluded in the config.

### DIFF
--- a/backend/config_manager.py
+++ b/backend/config_manager.py
@@ -20,15 +20,6 @@ def create_config(
     if not path_exists(path_to_testsuite) or not path_exists(path_to_binaries) or not path_exists(
             path_to_server_main) or not path_exists(path_to_index_builder):
         return False
-    directories = [
-        directory for directory in os.listdir(path_to_testsuite) if os.path.isdir(
-            os.path.join(
-                path_to_testsuite,
-                directory)) and os.path.isfile(
-            os.path.join(
-                path_to_testsuite,
-                directory,
-                "manifest.ttl"))]
     config = {
         "HOST": host,
         "GRAPHSTORE": graphstore,
@@ -41,15 +32,6 @@ def create_config(
         "port": port,
         "path_to_testsuite": path_to_testsuite,
         "path_to_binaries": path_to_binaries,
-        "queries": [
-            "Query.rq",
-            "Syntax.rq",
-            "Update.rq",
-            "Format.rq",
-            "Protocol.rq",
-            "Service.rq",
-            "GraphStoreProtocol.rq"],
-        "directories": directories,
         "alias": {
             "http://www.w3.org/2001/XMLSchema#integer": "http://www.w3.org/2001/XMLSchema#int",
             "http://www.w3.org/2001/XMLSchema#double": "http://www.w3.org/2001/XMLSchema#decimal",
@@ -64,7 +46,13 @@ def create_config(
             "http://www.w3.org/2001/XMLSchema#decimal",
             "http://www.w3.org/2001/XMLSchema#float",
             "http://www.w3.org/2001/XMLSchema#int",
-            "http://www.w3.org/2001/XMLSchema#decimal"]}
+            "http://www.w3.org/2001/XMLSchema#decimal"],
+        "exclude": [
+            "Service description contains a matching sd:endpoint triple",
+            "GET on endpoint returns RDF",
+            "Service description conforms to schema",
+            "POST - existing graph",
+        ]}
     write_json_file("config.json", config)
     return True
 

--- a/backend/extract_tests.py
+++ b/backend/extract_tests.py
@@ -158,6 +158,8 @@ def load_tests_from_manifest(
             path = manifest_abs_path.split("manifest.ttl")[0]
             entailment_regime = g.value(test_uri, SD.entailmentRegime)
             entailment_profile = g.value(test_uri, SD.entailmentProfile)
+            if str(name) in config.exclude:
+                continue
             tests.append(TestObject(
                 test=str(test_uri),
                 name=str(name),

--- a/backend/models.py
+++ b/backend/models.py
@@ -34,22 +34,19 @@ class Config:
         self.number_types = config.get('number_types')
         self.path_to_test_suite = os.path.abspath(config.get('path_to_testsuite'))
         self.path_to_binaries = os.path.abspath(config.get('path_to_binaries'))
-        self.queries = config.get('queries')
         self.command_index = config.get('command_index')
         self.command_start_server = config.get('command_start_server')
         self.command_stop_server = config.get('command_stop_server')
         self.command_remove_index = config.get('command_remove_index')
         self.server_address = config.get('server_address')
         self.port = config.get('port')
-        self.directories = config.get('directories')
+        self.exclude = config.get('exclude')
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert configuration to dictionary format."""
         return {
             'alias': self.alias,
             'number_types': self.number_types,
-            'queries': self.queries,
-            'directories': self.directories,
             'HOST': self.HOST,
             'GRAPHSTORE': self.GRAPHSTORE,
             'NEWPATH': self.NEWPATH


### PR DESCRIPTION
Tests can be excluded by adding them to the config. 
The optional **Entailment** tests and one empty test (nothing in the manifest except the name) are excluded by default.