### PR TITLE
Further work on Graphstore- / ProtocolTests

### DIFF
--- a/backend/protocol_tools.py
+++ b/backend/protocol_tools.py
@@ -43,9 +43,16 @@ def prepare_request(test: TestObject, request_with_reponse: str, newpath: str) -
     return request_header + '\r\n\r\n', request_body + '\r\n'
 
 
-def prepare_response(request_with_reponse: str) -> dict[str, str | list[str]]:
+def prepare_response(test: TestObject, request_with_reponse: str, newpath: str) -> dict[str, str | list[str]]:
     response: dict[str, str | list[str]] = {'status_codes': [], 'content_types': []}
     response_string = request_with_reponse.split('#### Response')[1]
+    if test.type_name == 'GraphStoreProtocolTest':
+        response_string = response_string.replace(
+            '$HOST$', test.config.HOST)
+        response_string = response_string.replace(
+            '$GRAPHSTORE$', test.config.GRAPHSTORE)
+        response_string = response_string.replace(
+            '$NEWPATH$', newpath)
     response_lines = [x.strip() for x in response_string.splitlines() if x]
     for line in response_lines:
         if line.endswith('response') or re.search(r'\dxx', line) is not None:
@@ -172,7 +179,7 @@ def run_protocol_test(
     for request_with_reponse in test_request_split:
         request_head, request_body = prepare_request(test, request_with_reponse, newpath)
         requests.append(request_head + request_body)
-        response = prepare_response(request_with_reponse)
+        response = prepare_response(test, request_with_reponse, newpath)
         responses.append(response)
         tn = telnet.Telnet(server_address, int(port))
         if 'charset=UTF-16' in request_head:

--- a/backend/protocol_tools.py
+++ b/backend/protocol_tools.py
@@ -15,7 +15,7 @@ def prepare_request(test: TestObject, request_with_reponse: str, newpath: str) -
         request = request.replace(
             '$HOST$', test.config.HOST)
         request = request.replace(
-            '$GRAPHSTORE$', test.config.GRAPHSTORE)
+            '$GRAPHSTORE$', '/' + test.config.GRAPHSTORE)
         request = request.replace(
             '$NEWPATH$', newpath)
     before_header = True

--- a/backend/rdf_tools.py
+++ b/backend/rdf_tools.py
@@ -83,8 +83,18 @@ def compare_ttl(expected_ttl: str, query_ttl: str) -> tuple:
     error_type = RESULTS_NOT_THE_SAME
     expected_graph = rdflib.Graph()
     query_graph = rdflib.Graph()
+    try:
+        expected_graph.parse(data=expected_ttl, format="turtle")
+    except Exception as e:
+        expected_ttl = '@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix v: <http://www.w3.org/2006/vcard/ns#> .\n\n' + expected_ttl
+        try:
+            expected_graph.parse(data=expected_ttl, format="turtle")
+        except Exception as e:
+            error_type = FORMAT_ERROR
+            escaped_expected = f'<label class="red">{escape(expected_ttl)}</label>'
+            return NOT_TESTED, error_type, escaped_expected, escape(query_ttl), f'<label class="red">{e}</label>', escape(
+                query_ttl)
 
-    expected_graph.parse(data=expected_ttl, format="turtle")
     try:
         query_graph.parse(data=query_ttl, format="turtle")
     except Exception as e:

--- a/backend/rdf_tools.py
+++ b/backend/rdf_tools.py
@@ -1,5 +1,5 @@
 import rdflib
-from backend.models import FAILED, PASSED, RESULTS_NOT_THE_SAME, FORMAT_ERROR
+from backend.models import FAILED, PASSED, RESULTS_NOT_THE_SAME, FORMAT_ERROR, NOT_TESTED
 import os
 import re
 from backend.util import escape
@@ -99,10 +99,10 @@ def compare_ttl(expected_ttl: str, query_ttl: str) -> tuple:
         query_graph.parse(data=query_ttl, format="turtle")
     except Exception as e:
         error_type = FORMAT_ERROR
-        escaped_querty = f'<label class="red">{escape(query_ttl)}</label>'
+        escaped_query = f'<label class="red">{escape(query_ttl)}</label>'
         escaped_expected = f'<label class="red">{escape(expected_ttl)}</label>'
         return status, error_type, escape(
-            expected_ttl), escaped_querty, escaped_expected, f'<label class="red">{e}</label>'
+            expected_ttl), escaped_query, escaped_expected, f'<label class="red">{e}</label>'
 
     is_isomorphic = expected_graph.isomorphic(query_graph)
 


### PR DESCRIPTION
1. Add missing leading `/` when replacing `$GRAPHSTORE$` #41 
2. Replace GraphstoreProtocolTest variables `$GRAPHSTORE$` `$HOST$` and `$NEWPATH$` in the expected response graphs.
3. If the expected graph is malformed, mark the test as `NOT TESTED` with the error type `FORMAT ERROR` but only after trying again with added prefixes.
    - Which essentially does the same as #40 . 
    - @Qup42 if this works for you I will close your PR.