### PR TITLE
Improve error visualization of GraphstoreProtocolTest

### DIFF
--- a/backend/config_manager.py
+++ b/backend/config_manager.py
@@ -52,6 +52,8 @@ def create_config(
             "service",
             "entailment",
             "POST - existing graph",
+            "PUT - mismatched payload",
+            "query specifying dataset in both query string and protocol; test for use of protocol-specified dataset"
         ]}
     write_json_file("config.json", config)
     return True

--- a/testsuite.py
+++ b/testsuite.py
@@ -409,7 +409,7 @@ class TestSuite:
             if not self.prepare_test_environment(
                     graph_path, graphs_list_of_tests[graph_path]):
                 break
-            newpath = ''
+            newpath = '/newpath-not-set'
             for test in graphs_list_of_tests[graph_path]:
                 if test.comment:
                     status, error_type, extracted_expected_responses, extracted_sent_requests, got_responses, new_newpath = run_protocol_test(


### PR DESCRIPTION
Initialize newpath with '/newpath-not-set' to make it clearer why a test failed