### PR TITLE
Fix graphstore replacement in GraphstoreProtocolTests

### DIFF
--- a/backend/protocol_tools.py
+++ b/backend/protocol_tools.py
@@ -40,8 +40,12 @@ def prepare_request(test: TestObject, request_with_reponse: str, newpath: str) -
     request_body = '\r\n'.join(request_body_lines)
     request_header = request_header + '\r\n' + 'Authorization: Bearer abc'
     if test.type_name == 'GraphStoreProtocolTest':
+        # Replace only the first occurrence with leading slash (in the request header),
+        # then replace remaining occurrences in header and body without the slash.
         request_header = request_header.replace(
-            '$GRAPHSTORE$', '/' + test.config.GRAPHSTORE)
+            '$GRAPHSTORE$', '/' + test.config.GRAPHSTORE, 1)
+        request_header = request_header.replace(
+            '$GRAPHSTORE$', test.config.GRAPHSTORE)
         request_body = request_body.replace(
             '$GRAPHSTORE$', test.config.GRAPHSTORE)
     request_header = request_header.replace('XXX', str(len(request_body)))


### PR DESCRIPTION
Fix issue #49 .
Replace only the first occurrence with leading slash (in the request header), then replace remaining occurrences in header and body without the slash.




Test `GET of PUT - initial state`
``` 
GET $GRAPHSTORE$?graph=http://$HOST$/$GRAPHSTORE$/person/1.ttl HTTP/1.1
Host: $HOST$
Accept: text/turtle
```

before:
```
GET /http-graph-store?graph=http://localhost//http-graph-store/person/1.ttl HTTP/1.1
Host: localhost
Accept: text/turtle
Content-Length: 0
Authorization: Bearer abc
```
now:
```
GET /sparql?graph=http://localhost/sparql/person/1.ttl HTTP/1.1
Host: localhost
Accept: text/turtle
Content-Length: 0
Authorization: Bearer abc
```