### PR TITLE
Make names of QLever binaries configurable

### DIFF
--- a/backend/config_manager.py
+++ b/backend/config_manager.py
@@ -11,12 +11,14 @@ def create_config(
         path_to_binaries: str,
         host: str,
         graphstore: str,
-        newpath: str) -> bool:
+        newpath: str,
+        server_binary: str,
+        index_binary: str) -> bool:
     """
     Create the config file.
     """
-    path_to_server_main = os.path.join(path_to_binaries, "ServerMain")
-    path_to_index_builder = os.path.join(path_to_binaries, "IndexBuilderMain")
+    path_to_server_main = os.path.join(path_to_binaries, server_binary)
+    path_to_index_builder = os.path.join(path_to_binaries, index_binary)
     if not path_exists(path_to_testsuite) or not path_exists(path_to_binaries) or not path_exists(
             path_to_server_main) or not path_exists(path_to_index_builder):
         return False

--- a/backend/qlever_manager.py
+++ b/backend/qlever_manager.py
@@ -8,7 +8,7 @@ from backend.rdf_tools import write_ttl_file, delete_ttl_file, rdf_xml_to_turtle
 
 def index(command_index: str, graph_paths: Tuple[Tuple[str, str], ...]) -> tuple:
     """
-    Executes a command to index a graph file using the QLever IndexBuilderMain binary.
+    Executes a command to index a graph file using the QLever qlever-index binary.
 
     Parameters:
         command_index: Command to be executed

--- a/testsuite.py
+++ b/testsuite.py
@@ -506,17 +506,17 @@ class TestSuite:
 def main():
     args = sys.argv[1:]
     if len(args) < 1:
-        print(f"  Usage to create config: python3 {sys.argv[0]} config <server address> <port> <path to testsuite> <path to the qlever binaries>  <graph store implementation host> <path of the URL of the graph store> <URL returned in the Location HTTP header>\n  Usage to extract tests: python3 {sys.argv[0]} extract \n  Usage to run tests: python3 {sys.argv[0]} <name for the test suite run>")
+        print(f"  Usage to create config: python3 {sys.argv[0]} config <server address> <port> <path to testsuite> <path to the qlever binaries> <graph store implementation host> <path of the URL of the graph store> <URL returned in the Location HTTP header> <server binary name> <index binary name>\n  Usage to extract tests: python3 {sys.argv[0]} extract \n  Usage to run tests: python3 {sys.argv[0]} <name for the test suite run>")
         return
 
     if args[0] == "config":
-        if len(args) == 8:
+        if len(args) == 10:
             print(f"Create basic config.")
             config_manager.create_config(
-                args[1], args[2], args[3], args[4], args[5], args[6], args[7])
+                args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8], args[9])
         else:
             print(
-                f"Usage to create config: python3 {sys.argv[0]} config <server address> <port> <path to testsuite> <path to the qlever binaries> <graph store implementation host> <path of the URL of the graph store> <URL returned in the Location HTTP header>")
+                f"Usage to create config: python3 {sys.argv[0]} config <server address> <port> <path to testsuite> <path to the qlever binaries> <graph store implementation host> <path of the URL of the graph store> <URL returned in the Location HTTP header> <server binary name> <index binary name>")
             return
 
     config = config_manager.initialize_config()
@@ -531,7 +531,7 @@ def main():
         test_suite.run()
         test_suite.generate_json_file()
     elif args[0] != "config" and args[0] != "extract":
-        print(f"  Usage to create config: python3 {sys.argv[0]} config <server address> <port> <path to testsuite> <path to binaries> <graph store implementation host> <path of the URL of the graph store> <URL returned in the Location HTTP header> \n  Usage to extract tests: python3 {sys.argv[0]} extract \n  Usage to run tests: python3 {sys.argv[0]} <name for the test suite run>")
+        print(f"  Usage to create config: python3 {sys.argv[0]} config <server address> <port> <path to testsuite> <path to binaries> <graph store implementation host> <path of the URL of the graph store> <URL returned in the Location HTTP header> <server binary name> <index binary name> \n  Usage to extract tests: python3 {sys.argv[0]} extract \n  Usage to run tests: python3 {sys.argv[0]} <name for the test suite run>")
         return
     print("Done!")
     return


### PR DESCRIPTION
This goes hand in hand with https://github.com/ad-freiburg/qlever/pull/2651, which sets the names of the binaries In `.github/workflows/sparql-conformance.yml` (which checks out this repository and requires this change)