### PR TITLE
Expose SERVICE endpoint fixtures in results

### DIFF
--- a/docs/results.md
+++ b/docs/results.md
@@ -23,7 +23,8 @@ fields. Actual test entries contain additional diagnostics and source data.
           "status": "Passed",
           "errorType": "",
           "executionQuery": "SELECT * WHERE { ?s ?p ?o }",
-          "datasetSources": []
+          "datasetSources": [],
+          "serviceData": []
         }
       },
       "info": {
@@ -55,6 +56,32 @@ Test entries include manifest metadata, the query and graph inputs, execution
 diagnostics, engine logs, and expected/actual output. Fields such as
 `expectedHtml`, `gotHtml`, `expectedHtmlRed`, and `gotHtmlRed` are
 display-oriented HTML used by the result viewer.
+
+SERVICE/federation query tests also include their endpoint fixtures in
+`serviceData`, in manifest order:
+
+```json
+{
+  "serviceData": [
+    {
+      "endpoint": "http://example1.org/sparql",
+      "fileName": "data02endpoint1.ttl",
+      "content": "@prefix : <http://example.org/> .\n..."
+    }
+  ]
+}
+```
+
+`endpoint` is the canonical URL from the manifest, `fileName` is only the
+fixture basename, and `content` is the exact UTF-8 source text loaded into the
+mock endpoint. Tests without SERVICE fixtures use an empty array. This field is
+independent of `datasetSources`, which describes local datasets referenced by
+query dataset clauses such as `FROM` and `FROM NAMED`.
+
+For federation tests, `queryFile` retains the original query while
+`executionQuery` records the endpoint-rewritten query sent to the engine. The
+mock URL in that diagnostic field can be ephemeral; the stable endpoint
+identity is always the canonical `serviceData[].endpoint` value.
 
 Consumers should check `version`, ignore unknown test fields, and treat a
 missing `version` as the legacy single-suite format. The `--compare-to` command

--- a/src/sparql_conformance/test_object.py
+++ b/src/sparql_conformance/test_object.py
@@ -1,8 +1,9 @@
-from enum import Enum
 import json
 import os
+from dataclasses import dataclass
+from enum import Enum
 from pathlib import Path
-from typing import Optional, List, Union, Dict, Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from sparql_conformance.config import Config
 from sparql_conformance.dataset_tools import prepare_query_dataset
@@ -10,10 +11,66 @@ from sparql_conformance.result_set_tools import (
     expected_is_result_set,
     is_select_or_ask,
 )
-from sparql_conformance.util import local_name, read_file, escape
+from sparql_conformance.util import escape, local_name, read_file, uri_to_path
 
 if TYPE_CHECKING:
     from sparql_conformance.protocol_request import ProtocolRequest
+
+
+@dataclass(frozen=True)
+class ServiceDataFixture:
+    """A validated SERVICE endpoint fixture loaded from the manifest."""
+
+    endpoint: str
+    source_path: str
+    file_name: str
+    content: str
+
+
+def normalize_service_data(
+        service_data: Any,
+        test_path: str,
+) -> tuple[list[ServiceDataFixture], str]:
+    """Load SERVICE fixtures once and return them with any setup error."""
+    if service_data is None:
+        return [], ""
+
+    entries = service_data if isinstance(service_data, list) else [service_data]
+    fixtures: list[ServiceDataFixture] = []
+
+    for index, entry in enumerate(entries, start=1):
+        prefix = f"SERVICE fixture {index}"
+        if not isinstance(entry, dict):
+            return fixtures, f"{prefix} must be an object."
+
+        endpoint = entry.get("endpoint")
+        if not isinstance(endpoint, str) or not endpoint.strip():
+            return fixtures, f"{prefix} is missing a non-empty endpoint."
+
+        data_path = entry.get("data")
+        if not isinstance(data_path, str) or not data_path.strip():
+            return fixtures, f"{prefix} is missing a non-empty data path."
+        data_path = data_path.strip()
+
+        source_path = Path(uri_to_path(data_path))
+        if not source_path.is_absolute():
+            source_path = Path(test_path) / source_path
+
+        try:
+            source_path = source_path.resolve(strict=True)
+            content = source_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeError):
+            return fixtures, f"{prefix} data file is unreadable: {data_path}"
+
+        fixtures.append(ServiceDataFixture(
+            endpoint=endpoint.strip(),
+            source_path=str(source_path),
+            file_name=source_path.name,
+            content=content,
+        ))
+
+    return fixtures, ""
+
 
 class Status(str, Enum):
     PASSED = "Passed"
@@ -147,6 +204,17 @@ class TestObject:
         self.status = Status.NOT_TESTED
         self.index_files: Dict[str, str] = {}
         self.result_files: Dict[str, str] = {}
+        self.setup_error = ""
+        service_data = (
+            action_node.get("serviceData")
+            if isinstance(action_node, dict)
+            else None
+        )
+        self.service_data_fixtures, service_setup_error = (
+            normalize_service_data(service_data, self.path)
+        )
+        if service_setup_error:
+            self.setup_error = service_setup_error
 
         # Process action node
         if isinstance(action_node, dict):
@@ -174,7 +242,6 @@ class TestObject:
 
         self.execution_query = self.query_file
         self.dataset_sources = []
-        self.setup_error = ""
         if self.type_name in ("QueryEvaluationTest", "CSVResultFormatTest"):
             prepared_query = prepare_query_dataset(
                 self.query_file,
@@ -182,7 +249,11 @@ class TestObject:
             )
             self.execution_query = prepared_query.query
             self.dataset_sources = list(prepared_query.sources)
-            self.setup_error = prepared_query.setup_error
+            if prepared_query.setup_error:
+                self.setup_error = "\n".join(filter(None, (
+                    self.setup_error,
+                    prepared_query.setup_error,
+                )))
 
         self.expected_result_set = False
         if self.result_format in ("rdf", "ttl"):
@@ -245,6 +316,14 @@ class TestObject:
                     "graphIri": source.graph_iri,
                 }
                 for source in self.dataset_sources
+            ],
+            'serviceData': [
+                {
+                    "endpoint": fixture.endpoint,
+                    "fileName": fixture.file_name,
+                    "content": fixture.content,
+                }
+                for fixture in self.service_data_fixtures
             ],
             'graphFile': graph_html,
             'resultFile': escape(self.result_file),

--- a/src/sparql_conformance/testsuite.py
+++ b/src/sparql_conformance/testsuite.py
@@ -653,18 +653,11 @@ class TestSuite:
                     self._report_test(test)
                     continue
 
-                service_data = test.action_node.get('serviceData', []) if isinstance(test.action_node, dict) else []
-                if isinstance(service_data, dict):
-                    service_data = [service_data]
-
                 mock = MockSPARQLServer()
                 url_map: dict = {}
-                for sd in service_data:
-                    endpoint_url = sd.get('endpoint') if isinstance(sd, dict) else None
-                    data_path = sd.get('data') if isinstance(sd, dict) else None
-                    if endpoint_url and data_path:
-                        mock.add_endpoint(endpoint_url, util.read_file(data_path))
-                        url_map[endpoint_url] = None
+                for fixture in test.service_data_fixtures:
+                    mock.add_endpoint(fixture.endpoint, fixture.content)
+                    url_map[fixture.endpoint] = None
                 mock.start()
                 mock_host = _get_mock_host(self.config)
                 for orig in url_map:
@@ -673,6 +666,7 @@ class TestSuite:
                 query_text = test.execution_query
                 for orig, local in url_map.items():
                     query_text = query_text.replace(orig, local)
+                test.execution_query = query_text
 
                 if not self.prepare_test_environment(graph_key, [test]):
                     mock.stop()

--- a/test/test_e2e_rdflib.py
+++ b/test/test_e2e_rdflib.py
@@ -133,6 +133,7 @@ def test_result_file_is_valid_v2_json(run_results, tmp_path):
             "errorType",
             "executionQuery",
             "datasetSources",
+            "serviceData",
         ):
             assert field in entry
 

--- a/test/test_service_data_results.py
+++ b/test/test_service_data_results.py
@@ -1,0 +1,215 @@
+"""Tests for SERVICE endpoint fixture execution and result metadata."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from sparql_conformance.config import Config
+from sparql_conformance.test_object import ErrorMessage, Status, TestObject
+from sparql_conformance.testsuite import TestSuite
+
+
+def make_config(tmp_path: Path) -> Config:
+    return Config(
+        image=None,
+        system="native",
+        port="7001",
+        graph_store="sparql",
+        testsuite_dir=str(tmp_path),
+        type_alias=[],
+        binaries_directory="",
+        exclude=[],
+        include=None,
+    )
+
+
+def make_test(tmp_path: Path, service_data=None) -> TestObject:
+    query_path = tmp_path / "query.rq"
+    query_path.write_text(
+        "SELECT * WHERE { SERVICE <http://example.org/sparql> { ?s ?p ?o } }\n",
+        encoding="utf-8",
+    )
+    result_path = tmp_path / "result.srj"
+    result_path.write_text(
+        '{"head": {"vars": []}, "results": {"bindings": []}}',
+        encoding="utf-8",
+    )
+    action = {"query": str(query_path)}
+    if service_data is not None:
+        action["serviceData"] = service_data
+    return TestObject(
+        test="urn:test",
+        name="service-test",
+        type_name="QueryEvaluationTest",
+        group="service",
+        path=str(tmp_path),
+        action_node=action,
+        result_node={"data": str(result_path)},
+        approval=None,
+        approved_by=None,
+        comment=None,
+        entailment_regime=None,
+        entailment_profile=None,
+        feature=[],
+        config=make_config(tmp_path),
+    )
+
+
+def test_single_fixture_is_normalized_and_serialized_without_source_path(tmp_path):
+    fixture_path = tmp_path / "endpoint.ttl"
+    content = "@prefix ex: <http://example.org/> .\nex:s ex:p ex:o .\n"
+    fixture_path.write_text(content, encoding="utf-8")
+    test = make_test(tmp_path, {
+        "endpoint": "http://example.org/sparql",
+        "data": str(fixture_path),
+    })
+
+    assert len(test.service_data_fixtures) == 1
+    result = test.to_dict()
+    assert result["serviceData"] == [{
+        "endpoint": "http://example.org/sparql",
+        "fileName": "endpoint.ttl",
+        "content": content,
+    }]
+    assert str(tmp_path) not in json.dumps(result["serviceData"])
+
+
+def test_multiple_fixtures_preserve_manifest_order_and_empty_content(tmp_path):
+    first = tmp_path / "first.ttl"
+    second = tmp_path / "second.ttl"
+    first.write_text("first\n", encoding="utf-8")
+    second.write_text("", encoding="utf-8")
+    test = make_test(tmp_path, [
+        {"endpoint": "http://first.example/sparql", "data": str(first)},
+        {"endpoint": "http://second.example/sparql", "data": str(second)},
+    ])
+
+    assert [fixture.endpoint for fixture in test.service_data_fixtures] == [
+        "http://first.example/sparql",
+        "http://second.example/sparql",
+    ]
+    assert [fixture.content for fixture in test.service_data_fixtures] == [
+        "first\n",
+        "",
+    ]
+
+
+def test_non_service_test_serializes_empty_fixture_array(tmp_path):
+    assert make_test(tmp_path).to_dict()["serviceData"] == []
+
+
+@pytest.mark.parametrize(
+    ("service_data", "message"),
+    [
+        ({"data": "fixture.ttl"}, "missing a non-empty endpoint"),
+        ({"endpoint": "http://example.org/sparql"}, "missing a non-empty data path"),
+        (
+            {"endpoint": "http://example.org/sparql", "data": "missing.ttl"},
+            "data file is unreadable: missing.ttl",
+        ),
+    ],
+)
+def test_malformed_fixture_produces_setup_error(tmp_path, service_data, message):
+    test = make_test(tmp_path, service_data)
+
+    assert message in test.setup_error
+
+
+def test_unreadable_fixture_produces_setup_error(tmp_path):
+    directory = tmp_path / "fixture.ttl"
+    directory.mkdir()
+    test = make_test(tmp_path, {
+        "endpoint": "http://example.org/sparql",
+        "data": str(directory),
+    })
+
+    assert "SERVICE fixture 1 data file is unreadable" in test.setup_error
+
+
+def test_setup_error_skips_federation_execution(tmp_path):
+    class EngineThatMustNotRun:
+        def query(self, config, query, result_format):
+            raise AssertionError("query must not run")
+
+    test = make_test(tmp_path, {
+        "endpoint": "http://example.org/sparql",
+        "data": "missing.ttl",
+    })
+    suite = TestSuite(
+        name="service-error",
+        tests={"federation": {((),): [test]}},
+        test_count=1,
+        config=make_config(tmp_path),
+        engine_manager=EngineThatMustNotRun(),
+        results_dir=str(tmp_path),
+    )
+
+    suite.run_federation_tests({(): [test]})
+
+    assert test.status == Status.NOT_TESTED
+    assert test.error_type == ErrorMessage.TEST_SETUP_ERROR
+
+
+def test_federation_execution_uses_the_serialized_fixture_content(
+        tmp_path,
+        monkeypatch,
+):
+    fixture_path = tmp_path / "endpoint.ttl"
+    content = "<urn:s> <urn:p> <urn:o> .\n"
+    fixture_path.write_text(content, encoding="utf-8")
+    test = make_test(tmp_path, {
+        "endpoint": "http://example.org/sparql",
+        "data": str(fixture_path),
+    })
+    recorded_endpoints = []
+
+    class FakeMockServer:
+        def add_endpoint(self, endpoint, fixture_content):
+            recorded_endpoints.append((endpoint, fixture_content))
+
+        def start(self):
+            pass
+
+        def stop(self):
+            pass
+
+        def local_url_for(self, endpoint, host):
+            assert endpoint == "http://example.org/sparql"
+            return f"http://{host}:4321/mock"
+
+    class RecordingEngine:
+        def __init__(self):
+            self.queries = []
+
+        def query(self, config, query, result_format):
+            self.queries.append(query)
+            return 500, "expected test response"
+
+        def cleanup(self, config):
+            pass
+
+    monkeypatch.setattr(
+        "sparql_conformance.testsuite.MockSPARQLServer",
+        FakeMockServer,
+    )
+    engine = RecordingEngine()
+    suite = TestSuite(
+        name="service",
+        tests={"federation": {(): [test]}},
+        test_count=1,
+        config=make_config(tmp_path),
+        engine_manager=engine,
+        results_dir=str(tmp_path),
+    )
+    monkeypatch.setattr(suite, "prepare_test_environment", lambda *args: True)
+    monkeypatch.setattr(suite, "refresh_server_log", lambda *args: None)
+
+    suite.run_federation_tests({(): [test]})
+
+    assert recorded_endpoints == [(
+        test.to_dict()["serviceData"][0]["endpoint"],
+        test.to_dict()["serviceData"][0]["content"],
+    )]
+    assert "http://127.0.0.1:4321/mock" in engine.queries[0]
+    assert test.execution_query == engine.queries[0]


### PR DESCRIPTION
Normalize federation fixtures once, reuse them during execution and serialize their canonical endpoint data for diagnostics.

Related to:
https://github.com/ad-freiburg/sparql-conformance-ui/pull/3

Fix:
https://github.com/ad-freiburg/sparql-conformance/issues/62
> https://qlever.dev/sparql-conformance-ui-v2/run/1?test=SERVICE+test+2&suite=sparql11
> It could be that the conformance test is right to fail on this one, but I have no way to tell. Because not even the details page tells me what data was loaded into the dummy service endpoints.